### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
+This XML file does not appear to have any style information associated with it. The document tree is shown below.
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
 <channel>
 <title>Ads Transparency Status</title>
 <link>https://metastatus.com/ads-transparency</link>
 <atom:link href="https://metastatus.com/outage-events-feed-ads-transparency.rss" rel="self" type="application/rss+xml"/>
 <description>Status updates for Ads Transparency</description>
-<lastBuildDate>Thu, 04 Apr 2024 21:11:53 GMT</lastBuildDate>
+<lastBuildDate>Fri, 11 Jul 2025 17:31:55 GMT</lastBuildDate>
 </channel>
 </rss>


### PR DESCRIPTION
This XML file does not appear to have any style information associated with it. The document tree is shown below.
<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
<channel>
<title>Ads Transparency Status</title>
<link>https://metastatus.com/ads-transparency</link>
<atom:link href="https://metastatus.com/outage-events-feed-ads-transparency.rss" rel="self" type="application/rss+xml"/>
<description>Status updates for Ads Transparency</description>
<lastBuildDate>Fri, 11 Jul 2025 17:31:55 GMT</lastBuildDate>
</channel>
</rss>